### PR TITLE
Pip provider correction

### DIFF
--- a/kokki/cookbooks/pip/libraries/providers.py
+++ b/kokki/cookbooks/pip/libraries/providers.py
@@ -54,7 +54,7 @@ class PipPackageProvider(PackageProvider):
     def install_package(self, name, version):
         check_call([self.pip_binary_path, "install", name], stdout=PIPE, stderr=STDOUT)
 
-    def update_package(self, name, version):
+    def upgrade_package(self, name, version):
         self.install_package(name, version)
 
     def remove_package(self, name, version):


### PR DESCRIPTION
update_package exists only in the Pip provider (where others have upgrade_package), and the provider's exposed actions contains "upgrade", not "update"
