### PR TITLE
Corrects pip version installation

### DIFF
--- a/kokki/cookbooks/pip/libraries/providers.py
+++ b/kokki/cookbooks/pip/libraries/providers.py
@@ -26,14 +26,13 @@ class PipPackageProvider(PackageProvider):
     @property
     def candidate_version(self):
         if not hasattr(self, '_candidate_version'):
-            if re.match("^[A-Za-z0-9_.-]+$", self.resource.package_name):
+            if not self.resource.version and re.match("^[A-Za-z0-9_.-]+$", self.resource.package_name):
                 p = Popen([self.easy_install_binary_path, "-n", self.resource.package_name], stdout=PIPE, stderr=STDOUT)
                 out = p.communicate()[0]
                 res = p.wait()
                 if res != 0:
                     self.log.warning("easy_install check returned a non-zero result (%d) %s" % (res, self.resource))
-                #     self._candidate_version = None
-                # else:
+
                 m = best_match_re.search(out)
                 if not m:
                     self._candidate_version = None


### PR DESCRIPTION
The specified version of a package should take priority over the version found by easy_install, especially since the means by which kokki is determining the newest version of a package seems flawed.

Assuming I currently have pip version 0.3.1 installed and I have in a recipe the following:

```
env.cookbooks.pip.PipPackage(
    "pip",
    version = "0.8.2",
)
```

I would expect that this would install pip version 0.8.2. Instead, kokki uses "easy_install -n pip" to determine the version of pip to install. "easy_install -n $PACKAGE" will pick up the currently installed version of the package (in the case that it is already installed) as its "Best match", preventing upgrading entirely.

If we allow specified versions to take priority, we work around this shortcoming. I haven't figured out a way to get the newest version of a package correctly from easy_install, though ("easy_install -n --upgrade $PACKAGE" finds the correct version but then chokes).
