### PR TITLE
PipPackageProvider now respects versions

### DIFF
--- a/kokki/cookbooks/pip/libraries/providers.py
+++ b/kokki/cookbooks/pip/libraries/providers.py
@@ -51,7 +51,10 @@ class PipPackageProvider(PackageProvider):
         return "easy_install"
 
     def install_package(self, name, version):
-        check_call([self.pip_binary_path, "install", name], stdout=PIPE, stderr=STDOUT)
+        if name == 'pip' or not version:
+            check_call([self.pip_binary_path, "install", "--upgrade", name], stdout=PIPE, stderr=STDOUT)
+        else:
+            check_call([self.pip_binary_path, "install", '{0}=={1}'.format(name, version)], stdout=PIPE, stderr=STDOUT)
 
     def upgrade_package(self, name, version):
         self.install_package(name, version)


### PR DESCRIPTION
Previously, the provided version argument would not be used by PipPackageProvider. If not already installed, it would attempt to install the latest version of a package. If already installed, pip reports such and does nothing.

This change introduces installing of specific versions using
    pip install $PACKAGENAME==$VERSION

otherwise, it installs using
    pip install --upgrade $PACKAGENAME

which will upgrade if installed, otherwise install the latest version of the package.

One exception to this behavior is pip itself. When upgrading pip through pip, we cannot know if the version of pip is advanced enough to support this version notation, thus even when specified, it ignores it.
