### PR TITLE
Edited kokki/cookbooks/postgresql9/recipes/default.py via GitHub

### DIFF
--- a/kokki/cookbooks/postgresql9/recipes/default.py
+++ b/kokki/cookbooks/postgresql9/recipes/default.py
@@ -1,4 +1,3 @@
-
 import os
 from kokki import Execute
 
@@ -10,6 +9,7 @@ Execute("apt-update-postgresql9",
 
 apt = None
 if env.system.platform == "ubuntu":
-    Execute("apt-add-repository ppa:pitti/postgresql",
+    Package("python-software-properties")
+    Execute("add-apt-repository ppa:pitti/postgresql",
         not_if = lambda:os.path.exists(apt_list_path),
         notifies = [("run", env.resources["Execute"]["apt-update-postgresql9"], True)])


### PR DESCRIPTION
Some small fixes to get the Postgresql9 recipe to run. See http://www.dctrwatson.com/2010/09/installing-postgresql-9-0-on-ubuntu-10-04/
