### PR TITLE
Fixed a simple error in resources/system.py

### DIFF
--- a/kokki/resources/system.py
+++ b/kokki/resources/system.py
@@ -54,7 +54,7 @@ class Script(Resource):
     user = ResourceArgument()
     group = ResourceArgument()
 
-    action = Resource.actions + ["run"]
+    actions = Resource.actions + ["run"]
 
 class Mount(Resource):
     action = ForcedListArgument(default="mount")


### PR DESCRIPTION
Script action should be actions, otherwise no matter which action we provide, it will always be overridden to run
